### PR TITLE
Add missing remember_token

### DIFF
--- a/lib/generators/neo4j/devise_generator.rb
+++ b/lib/generators/neo4j/devise_generator.rb
@@ -46,6 +46,7 @@ module Neo4j
 
      ## Rememberable
      property :remember_created_at, type: DateTime
+     property :remember_token
      index :remember_token
 
 


### PR DESCRIPTION
6.0.0 fails harder than before when this is missing (for good reason)